### PR TITLE
Modify platformio.ini to allow use of deprecated ArduinoJson libraries

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,12 +15,14 @@ board_build.f_cpu = 160000000L
 framework = arduino
 ;upload_flags = --port=8266 --auth=esp-react
 ;upload_port = 192.168.0.6
+monitor_speed = 115200
+
 build_flags=
   -D NO_GLOBAL_ARDUINOOTA
 ; -D ENABLE_CORS
 lib_deps =
   https://github.com/PaulStoffregen/Time
   https://github.com/gmag11/NtpClient
-  https://github.com/bblanchon/ArduinoJson
+  ArduinoJson@>=5.0.0,<6.0.0
   https://github.com/me-no-dev/ESPAsyncWebServer
   https://github.com/me-no-dev/AsyncTCP


### PR DESCRIPTION
This project fails to build with environments using the latest versions of ArduinoJson (anything post 5.13).  This edit allows the existing codebase compile using ArduinoJson v5.x objects that have been deprecated in newer library releases.