### PR TITLE
Corrected issues while enabling static IP on web.

### DIFF
--- a/src/WiFiSettingsService.cpp
+++ b/src/WiFiSettingsService.cpp
@@ -77,7 +77,7 @@ void WiFiSettingsService::reconfigureWiFiConnection() {
 }
 
 void WiFiSettingsService::readIP(JsonObject& root, String key, IPAddress& _ip){
-  if (!root[key] || !_ip.fromString(root[key].as<String>())){
+  if ( root[key].isNull() || !_ip.fromString(root[key].as<String>())){
     _ip = INADDR_NONE;
   }
 }


### PR DESCRIPTION
Hi, I was having problems setting a static IP on the web, although React was sending the event correctly the backend was not working. I found that for some reason root[key] is always false and _ip always gets set to INADDR_NONE. Changing the conditional to root[key].isNull() corrected the issue and keeps the logic.

BTW: Thanks for this great project!