### PR TITLE
[ESP8266/ESP32] Problem setting hostname while on dynamic ip.

### DIFF
--- a/src/WiFiSettingsService.cpp
+++ b/src/WiFiSettingsService.cpp
@@ -67,13 +67,15 @@ void WiFiSettingsService::reconfigureWiFiConnection() {
     }
 
     // connect to the network
-#if defined(ESP8266)
-    WiFi.hostname(_hostname);
-#elif defined(ESP_PLATFORM)
+#if defined(ESP_PLATFORM)
     WiFi.setHostname(_hostname.c_str());
 #endif
 
     WiFi.begin(_ssid.c_str(), _password.c_str());
+
+#if defined(ESP8266)
+    WiFi.hostname(_hostname);
+#endif
 }
 
 void WiFiSettingsService::readIP(JsonObject& root, String key, IPAddress& _ip){

--- a/src/WiFiSettingsService.cpp
+++ b/src/WiFiSettingsService.cpp
@@ -64,18 +64,18 @@ void WiFiSettingsService::reconfigureWiFiConnection() {
     // configure static ip config for station mode (if set)
     if (_staticIPConfig) {
       WiFi.config(_localIP, _gatewayIP,  _subnetMask, _dnsIP1, _dnsIP2);
+    } else { // else setting dynamic ip config and hostname
+#if defined(ESP8266) 
+      WiFi.config(INADDR_ANY, INADDR_ANY, INADDR_ANY);
+      WiFi.hostname(_hostname);
+#elif defined(ESP_PLATFORM)
+      WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+      WiFi.setHostname(_hostname.c_str());
+#endif
     }
 
     // connect to the network
-#if defined(ESP_PLATFORM)
-    WiFi.setHostname(_hostname.c_str());
-#endif
-
     WiFi.begin(_ssid.c_str(), _password.c_str());
-
-#if defined(ESP8266)
-    WiFi.hostname(_hostname);
-#endif
 }
 
 void WiFiSettingsService::readIP(JsonObject& root, String key, IPAddress& _ip){


### PR DESCRIPTION
While using a dynamic ip the system doesn't take into account the hostname setting.
Calling WiFi.hostname() after begin() solved the issue.
This only applies to esp8266, haven't tried on esp32.