### PR TITLE
disable sorting of include blocks - it's breaking the ESP32 build.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,3 +13,4 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ExperimentalAutoDetectBinPacking: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 DerivePointerAlignment: false
+SortIncludes: false


### PR DESCRIPTION
Fixing auto-formatter issue which was messing up the headers and causing ESP32 builds to fail.