### PR TITLE
PlatformIO 4.2.0 fix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -31,8 +31,10 @@ lib_deps =
 platform = espressif8266
 board = esp12e
 board_build.f_cpu = 160000000L
+lib_ignore = AsyncTCP
 
 [env:node32s]
 ;board_build.partitions = min_spiffs.csv
 platform = espressif32
 board = node32s
+lib_ignore = ESPAsyncTCP


### PR DESCRIPTION
Fix issue with PlatformIO 4.2.0 no longer discriminating transitive dependencies from ESPAsyncWebServer's library.json correctly.