### PR TITLE
Add missing security manager include to WebSocketTxRx.h

### DIFF
--- a/lib/framework/WebSocketTxRx.h
+++ b/lib/framework/WebSocketTxRx.h
@@ -3,6 +3,7 @@
 
 #include <StatefulService.h>
 #include <ESPAsyncWebServer.h>
+#include <SecurityManager.h>
 
 #define WEB_SOCKET_CLIENT_ID_MSG_SIZE 128
 


### PR DESCRIPTION
Previously the demo code was relying on the transitive include via HttpEndpoint.h
This change allows WebSocketTxRx.h to be used when no HttpEndpoint is in use