### PR TITLE
assert lengths for AP factory settings

### DIFF
--- a/lib/framework/APSettingsService.h
+++ b/lib/framework/APSettingsService.h
@@ -9,6 +9,9 @@
 #include <DNSServer.h>
 #include <IPAddress.h>
 
+#define CHECK_LEN(s, min_len, max_len) \
+  static_assert(min_len <= sizeof(s) && sizeof(s) <= max_len, #s " should have " #min_len "-" #max_len " characters.")
+
 #ifndef FACTORY_AP_PROVISION_MODE
 #define FACTORY_AP_PROVISION_MODE AP_MODE_DISCONNECTED
 #endif
@@ -17,9 +20,13 @@
 #define FACTORY_AP_SSID "ESP8266-React-#{unique_id}"
 #endif
 
+CHECK_LEN(FACTORY_AP_SSID, 1, 64);
+
 #ifndef FACTORY_AP_PASSWORD
 #define FACTORY_AP_PASSWORD "esp-react"
 #endif
+
+CHECK_LEN(FACTORY_AP_PASSWORD, 8, 64);
 
 #ifndef FACTORY_AP_LOCAL_IP
 #define FACTORY_AP_LOCAL_IP "192.168.4.1"


### PR DESCRIPTION
This adds a bit of protection against improper factory AP settings. 

The issue is that even when these settings are invalid, they are still stored into flash memory. This means that the access point will not be visible until I wipe the flash clean.

It took me a few hours to debug why the software AP just won't come up... Hope this commit can spare others from jumping into the same hole.