### PR TITLE
Upgrade  for Arduino-Espressif32 2.0.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /interface/node_modules
 /interface/.eslintcache
 .vscode
+src/WWWData.h

--- a/lib/framework/MqttSettingsService.cpp
+++ b/lib/framework/MqttSettingsService.cpp
@@ -34,9 +34,9 @@ MqttSettingsService::MqttSettingsService(AsyncWebServer* server, FS* fs, Securit
 #ifdef ESP32
   WiFi.onEvent(
       std::bind(&MqttSettingsService::onStationModeDisconnected, this, std::placeholders::_1, std::placeholders::_2),
-      WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
   WiFi.onEvent(std::bind(&MqttSettingsService::onStationModeGotIP, this, std::placeholders::_1, std::placeholders::_2),
-               WiFiEvent_t::SYSTEM_EVENT_STA_GOT_IP);
+               WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
 #elif defined(ESP8266)
   _onStationModeDisconnectedHandler = WiFi.onStationModeDisconnected(
       std::bind(&MqttSettingsService::onStationModeDisconnected, this, std::placeholders::_1));

--- a/lib/framework/NTPSettingsService.cpp
+++ b/lib/framework/NTPSettingsService.cpp
@@ -13,9 +13,9 @@ NTPSettingsService::NTPSettingsService(AsyncWebServer* server, FS* fs, SecurityM
 #ifdef ESP32
   WiFi.onEvent(
       std::bind(&NTPSettingsService::onStationModeDisconnected, this, std::placeholders::_1, std::placeholders::_2),
-      WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
   WiFi.onEvent(std::bind(&NTPSettingsService::onStationModeGotIP, this, std::placeholders::_1, std::placeholders::_2),
-               WiFiEvent_t::SYSTEM_EVENT_STA_GOT_IP);
+               WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
 #elif defined(ESP8266)
   _onStationModeDisconnectedHandler = WiFi.onStationModeDisconnected(
       std::bind(&NTPSettingsService::onStationModeDisconnected, this, std::placeholders::_1));

--- a/lib/framework/OTASettingsService.cpp
+++ b/lib/framework/OTASettingsService.cpp
@@ -6,7 +6,7 @@ OTASettingsService::OTASettingsService(AsyncWebServer* server, FS* fs, SecurityM
     _arduinoOTA(nullptr) {
 #ifdef ESP32
   WiFi.onEvent(std::bind(&OTASettingsService::onStationModeGotIP, this, std::placeholders::_1, std::placeholders::_2),
-               WiFiEvent_t::SYSTEM_EVENT_STA_GOT_IP);
+               WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
 #elif defined(ESP8266)
   _onStationModeGotIPHandler =
       WiFi.onStationModeGotIP(std::bind(&OTASettingsService::onStationModeGotIP, this, std::placeholders::_1));

--- a/lib/framework/WiFiSettingsService.cpp
+++ b/lib/framework/WiFiSettingsService.cpp
@@ -19,9 +19,9 @@ WiFiSettingsService::WiFiSettingsService(AsyncWebServer* server, FS* fs, Securit
   WiFi.mode(WIFI_MODE_NULL);
   WiFi.onEvent(
       std::bind(&WiFiSettingsService::onStationModeDisconnected, this, std::placeholders::_1, std::placeholders::_2),
-      WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
   WiFi.onEvent(std::bind(&WiFiSettingsService::onStationModeStop, this, std::placeholders::_1, std::placeholders::_2),
-               WiFiEvent_t::SYSTEM_EVENT_STA_STOP);
+               WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_STOP);
 #elif defined(ESP8266)
   _onStationModeDisconnectedHandler = WiFi.onStationModeDisconnected(
       std::bind(&WiFiSettingsService::onStationModeDisconnected, this, std::placeholders::_1));
@@ -71,10 +71,10 @@ void WiFiSettingsService::manageSTA() {
     } else {
       // configure for DHCP
 #ifdef ESP32
-      WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+      //WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
       WiFi.setHostname(_state.hostname.c_str());
 #elif defined(ESP8266)
-      WiFi.config(INADDR_ANY, INADDR_ANY, INADDR_ANY);
+      //WiFi.config(INADDR_ANY, INADDR_ANY, INADDR_ANY);
       WiFi.hostname(_state.hostname);
 #endif
     }

--- a/lib/framework/WiFiStatus.cpp
+++ b/lib/framework/WiFiStatus.cpp
@@ -6,9 +6,9 @@ WiFiStatus::WiFiStatus(AsyncWebServer* server, SecurityManager* securityManager)
              securityManager->wrapRequest(std::bind(&WiFiStatus::wifiStatus, this, std::placeholders::_1),
                                           AuthenticationPredicates::IS_AUTHENTICATED));
 #ifdef ESP32
-  WiFi.onEvent(onStationModeConnected, WiFiEvent_t::SYSTEM_EVENT_STA_CONNECTED);
-  WiFi.onEvent(onStationModeDisconnected, WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
-  WiFi.onEvent(onStationModeGotIP, WiFiEvent_t::SYSTEM_EVENT_STA_GOT_IP);
+  WiFi.onEvent(onStationModeConnected, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_CONNECTED);
+  WiFi.onEvent(onStationModeDisconnected, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+  WiFi.onEvent(onStationModeGotIP, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
 #elif defined(ESP8266)
   _onStationModeConnectedHandler = WiFi.onStationModeConnected(onStationModeConnected);
   _onStationModeDisconnectedHandler = WiFi.onStationModeDisconnected(onStationModeDisconnected);
@@ -23,7 +23,7 @@ void WiFiStatus::onStationModeConnected(WiFiEvent_t event, WiFiEventInfo_t info)
 
 void WiFiStatus::onStationModeDisconnected(WiFiEvent_t event, WiFiEventInfo_t info) {
   Serial.print(F("WiFi Disconnected. Reason code="));
-  Serial.println(info.disconnected.reason);
+  Serial.println(info.wifi_sta_disconnected.reason);
 }
 
 void WiFiStatus::onStationModeGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,7 @@ extra_scripts =
 
 lib_deps =
   ArduinoJson@>=6.0.0,<7.0.0
-  ESP Async WebServer@>=1.2.0,<2.0.0
+  https://github.com/me-no-dev/ESPAsyncWebServer.git
   AsyncMqttClient@>=0.8.2,<1.0.0
   
 [env:esp12e]
@@ -43,8 +43,14 @@ board = esp12e
 board_build.f_cpu = 160000000L
 board_build.filesystem = littlefs
 
-[env:node32s]
 ; Comment out min_spiffs.csv setting if disabling PROGMEM_WWW with ESP32
-board_build.partitions = min_spiffs.csv
-platform = espressif32
+
+[env:node32s]
+platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.3rc1/platform-espressif32-2.0.3.zip
 board = node32s
+board_build.partitions = min_spiffs.csv
+
+[env:esp32dev]
+platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.3rc1/platform-espressif32-2.0.3.zip
+board = esp32dev
+board_build.partitions = min_spiffs.csv


### PR DESCRIPTION
While 2.0.x is not available in PIO let's use Tasmota repository.

I have tested this code with NodeMCU and ESP32-Wroover IE.

In This PR I haven't changed the file structure.