### PR TITLE
Add dark mode

### DIFF
--- a/interface/src/CustomTheme.tsx
+++ b/interface/src/CustomTheme.tsx
@@ -1,4 +1,5 @@
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import { CssBaseline } from '@mui/material';
 import { createTheme, responsiveFontSizes, ThemeProvider } from '@mui/material/styles';
@@ -6,35 +7,41 @@ import { indigo, blueGrey, orange, red, green } from '@mui/material/colors';
 
 import { RequiredChildrenProps } from './utils';
 
-const theme = responsiveFontSizes(
-  createTheme({
-    palette: {
-      background: {
-        default: "#fafafa"
-      },
-      primary: indigo,
-      secondary: blueGrey,
-      info: {
-        main: indigo[500]
-      },
-      warning: {
-        main: orange[500]
-      },
-      error: {
-        main: red[500]
-      },
-      success: {
-        main: green[500]
-      }
-    }
-  })
-);
+const CustomTheme: FC<RequiredChildrenProps> = ({ children }) => {
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 
-const CustomTheme: FC<RequiredChildrenProps> = ({ children }) => (
-  <ThemeProvider theme={theme}>
-    <CssBaseline />
-    {children}
-  </ThemeProvider>
-);
+  const theme = useMemo(
+      () =>
+      responsiveFontSizes(
+        createTheme({
+          palette: {
+            mode: prefersDarkMode ? 'dark' : 'light',
+            primary: indigo,
+            secondary: blueGrey,
+            info: {
+              main: indigo[500]
+            },
+            warning: {
+              main: orange[500]
+            },
+            error: {
+              main: red[500]
+            },
+            success: {
+              main: green[500]
+            }
+          }
+        }),
+      ),
+    [prefersDarkMode],
+    );
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
+};
 
 export default CustomTheme;


### PR DESCRIPTION
I've added a line that looks up a user's preferred mode and sets it according to browser preferences.

To make it work I had to remove the custom background color (#fafafa), since it would be set after the dark or light theme was selected. Resulting in a dark mode with a white background.

The current background color is now (#ffffff) 

I will try and see if I can re-incorporate the custom background-color