### PR TITLE
Add mDNS

### DIFF
--- a/lib/framework/ESP8266React.h
+++ b/lib/framework/ESP8266React.h
@@ -6,9 +6,11 @@
 #ifdef ESP32
 #include <AsyncTCP.h>
 #include <WiFi.h>
+#include <ESPmDNS.h>
 #elif defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <ESPAsyncTCP.h>
+#include <ESP8266mDNS.h>
 #endif
 
 #include <FeaturesService.h>

--- a/lib/framework/WiFiSettingsService.cpp
+++ b/lib/framework/WiFiSettingsService.cpp
@@ -80,6 +80,7 @@ void WiFiSettingsService::manageSTA() {
     }
     // attempt to connect to the network
     WiFi.begin(_state.ssid.c_str(), _state.password.c_str());
+    MDNS.begin(_state.hostname.c_str());
   }
 }
 

--- a/lib/framework/WiFiSettingsService.h
+++ b/lib/framework/WiFiSettingsService.h
@@ -7,6 +7,14 @@
 #include <HttpEndpoint.h>
 #include <JsonUtils.h>
 
+#ifdef ESP32
+#include <WiFi.h>
+#include <ESPmDNS.h>
+#elif defined(ESP8266)
+#include <ESP8266WiFi.h>
+#include <ESP8266mDNS.h>
+#endif
+
 #ifndef FACTORY_WIFI_SSID
 #define FACTORY_WIFI_SSID ""
 #endif


### PR DESCRIPTION
I've added mDNS to the wifiSettingsService. 

With mDNS users can reach their devices using hostname.local addresses instead of IP adresses.