### PR TITLE
Update summer/winter time changeover

### DIFF
--- a/lib/framework/NTPSettingsService.cpp
+++ b/lib/framework/NTPSettingsService.cpp
@@ -77,6 +77,7 @@ void NTPSettingsService::configureTime(AsyncWebServerRequest* request, JsonVaria
     String timeLocal = json["local_time"];
     char* s = strptime(timeLocal.c_str(), "%Y-%m-%dT%H:%M:%S", &tm);
     if (s != nullptr) {
+      tm.tm_isdst = -1; // not set by strptime, tells mktime to determine daylight saving
       time_t time = mktime(&tm);
       struct timeval now = {.tv_sec = time};
       settimeofday(&now, nullptr);


### PR DESCRIPTION
Daylight saving time is not updated by strptime.
Set **tm_isdst** parameter in _NTPSettingsService::ConfigureTime()_ to determine daylight saving time.