### PR TITLE
more boards tested

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -46,9 +46,26 @@ board = esp12e
 board_build.f_cpu = 160000000L
 board_build.filesystem = littlefs
 
+[env:nodemcu]
+platform = espressif8266
+board = nodemcu
+board_build.filesystem = littlefs
+
 [env:node32s]
 ; Comment out min_spiffs.csv setting if disabling PROGMEM_WWW with ESP32
 board_build.partitions = min_spiffs.csv
 platform = espressif32
 board = node32s
+board_build.filesystem = littlefs
+
+[env:esp32wbat]
+board_build.partitions = min_spiffs.csv
+platform = espressif32
+board = wemosbat
+board_build.filesystem = littlefs
+
+[env:wemos mini pro]
+board_build.partitions = min_spiffs.csv
+platform = espressif8266
+board = d1_mini_pro
 board_build.filesystem = littlefs

--- a/src/LightStateService.h
+++ b/src/LightStateService.h
@@ -7,7 +7,7 @@
 #include <MqttPubSub.h>
 #include <WebSocketTxRx.h>
 
-#define LED_PIN 2
+#define LED_PIN LED_BUILTIN
 
 #define DEFAULT_LED_STATE false
 #define OFF_STATE "OFF"
@@ -16,8 +16,8 @@
 // Note that the built-in LED is on when the pin is low on most NodeMCU boards.
 // This is because the anode is tied to VCC and the cathode to the GPIO 4 (Arduino pin 2).
 #ifdef ESP32
-#define LED_ON 0x1
-#define LED_OFF 0x0
+#define LED_ON 0x0
+#define LED_OFF 0x1
 #elif defined(ESP8266)
 #define LED_ON 0x0
 #define LED_OFF 0x1


### PR DESCRIPTION
I tested on ESP32 wemos battery(with a li-ion 18650 battery holder) with excelent result, but the needed to change the led to LED_BUILDIN and the states ON OFF result to be the same as the eso8266,
I also tested in 2 esp8266: the wemos mini D1 pro and the nodemcu. both works ok, but they get reset when manuali change the led state with websockets at high frequency.
I consider this a great project, I hope you consider my simple contribution so I can make more of them in the future. 