### PR TITLE
Fix for espressif32@6.4.0

### DIFF
--- a/lib/framework/WiFiSettingsService.cpp
+++ b/lib/framework/WiFiSettingsService.cpp
@@ -4,6 +4,10 @@ WiFiSettingsService::WiFiSettingsService(AsyncWebServer* server, FS* fs, Securit
     _httpEndpoint(WiFiSettings::read, WiFiSettings::update, this, server, WIFI_SETTINGS_SERVICE_PATH, securityManager),
     _fsPersistence(WiFiSettings::read, WiFiSettings::update, this, fs, WIFI_SETTINGS_FILE),
     _lastConnectionAttempt(0) {
+  addUpdateHandler([&](const String& originId) { reconfigureWiFiConnection(); }, false);
+}
+
+void WiFiSettingsService::begin() {
   // We want the device to come up in opmode=0 (WIFI_OFF), when erasing the flash this is not the default.
   // If needed, we save opmode=0 before disabling persistence so the device boots with WiFi disabled in the future.
   if (WiFi.getMode() != WIFI_OFF) {
@@ -27,10 +31,6 @@ WiFiSettingsService::WiFiSettingsService(AsyncWebServer* server, FS* fs, Securit
       std::bind(&WiFiSettingsService::onStationModeDisconnected, this, std::placeholders::_1));
 #endif
 
-  addUpdateHandler([&](const String& originId) { reconfigureWiFiConnection(); }, false);
-}
-
-void WiFiSettingsService::begin() {
   _fsPersistence.readFromFS();
   reconfigureWiFiConnection();
 }


### PR DESCRIPTION
Wifi intialization has to be done in begin() function to avoid bootloop.